### PR TITLE
Fix SwiftUI Preview issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,16 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Hover",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .watchOS(.v6),
+        .tvOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/Hover/Hover.swift
+++ b/Sources/Hover/Hover.swift
@@ -7,9 +7,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 public typealias VoidResultCompletion = (Result<Response, ProviderError>) -> Void
 

--- a/Sources/HoverTests/Test Source/TestClass.swift
+++ b/Sources/HoverTests/Test Source/TestClass.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
+
 @testable import Hover
 
 typealias PostCompletion = (Result<PostResponseElement, ProviderError>) -> Void


### PR DESCRIPTION
- Bumped swift tools version to 5.3
- Added platforms indicator to Package.swift for SPM
- Removed canImport statements, since it's not required anymore.